### PR TITLE
Use Jekyll layouts to correctly set up script tags and other `<head>` elements.

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # *A Living Review of Quantum Computing for Plasma Physics*
 
 *Quantum Computing promises accelerated simulation of certain classes of problems, in particular in plasma physics. The goal of this document is to provide a comprehensive list of citations for those developing and applying these approaches to experimental or theoretical analyses. As a living document, it will be updated as often as possible to incorporate the latest developments.  Suggestions are most welcome.*

--- a/CONTENT.md
+++ b/CONTENT.md
@@ -108,7 +108,7 @@ In order to be as useful as possible, this document will continue to evolve so p
 		
 			*Many problems can be mapped to the Schrödinger equation*
 			
-			$$\mathrm{i}\hbar \partial_t \ket{\psi(t)} = H\ket{\psi(t)}$$
+			$$\mathrm{i}\hbar \partial_t \vert{\psi(t)}\rangle = H\vert{\psi(t)}\rangle$$
 			
 			*described by some Hamiltonian H. Solving the Schrödinger equation can often be done much more efficiently with quantum computers.*
 				

--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,17 +1,5 @@
 # *A Living Review of Quantum Computing for Plasma Physics*
 
-<!DOCTYPE html>
-<script>window.texme = { style: 'none' }</script>
-<script src="https://cdn.jsdelivr.net/npm/texme@1.2.2"></script>
-<style>
-main {
-  max-width: 60em;
-  padding: 2em;
-  margin: 2em auto;
-}
-</style>
-<textarea>
-
 *Quantum Computing promises accelerated simulation of certain classes of problems, in particular in plasma physics. The goal of this document is to provide a comprehensive list of citations for those developing and applying these approaches to experimental or theoretical analyses. As a living document, it will be updated as often as possible to incorporate the latest developments.  Suggestions are most welcome.*
 
 [![download](https://img.shields.io/badge/download-review-blue.svg)](https://QPPQLivingReview.github.io/review/review/review.pdf)

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+name: A Living Review of Quantum Computing for Plasma Physics
 theme: jekyll-theme-cayman
 github:
   is_project_page: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>A Living Review of Quantum Computing for Plasma Physics</title>
+  <style>
+  main {
+    max-width: 60em;
+    padding: 2em;
+    margin: 2em auto;
+  }
+  </style>
+  <script
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"
+  type="text/javascript"></script>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+    {{ content }}
+</body>
+</html>


### PR DESCRIPTION
This pull request uses [Jekyll's layout feature](https://jekyllrb.com/tutorials/convert-site-to-jekyll/) to define a custom header for the rendered HTML file.

Previously, these elements were defined in the main markdown itself, some of it being misinterpreted as literal text.

**This pull request is untested** as it depends on Github's build process, and my CNAME is interfering with the process in my branch.